### PR TITLE
Fix bug in about due to wrong parenthesis

### DIFF
--- a/src/minimalkb/backends/sqlite.py
+++ b/src/minimalkb/backends/sqlite.py
@@ -113,8 +113,9 @@ class SQLStore:
         query = '''
                 SELECT subject, predicate, object 
                 FROM %s
-                WHERE (subject=:res OR predicate=:res OR object IN ('"%s"',:res)
-                AND model IN (%s))''' % (TRIPLETABLENAME, resource, ",".join([":m%s" % i for i in range(len(models))]))
+                WHERE ((subject=:res OR predicate=:res OR object IN ('"%s"',:res))
+                       AND model IN (%s))''' % (TRIPLETABLENAME, resource, ",".join([":m%s" % i for i in range(len(models))]))
+        
         with self.conn:
             res = self.conn.execute(query, params)
             return [[row[0], row[1], row[2]] for row in res]

--- a/testing/test.py
+++ b/testing/test.py
@@ -206,7 +206,13 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertFalse(self.kb["* isNice true"])
         self.assertItemsEqual(self.kb["* isNice false"], ['nono'])
 
+    def test_about(self):
+        self.kb.add(["nono isNice true"], ["model1"])
+        self.kb.add(["jamesbond isNice true"], ["model2"])
+        self.assertTrue(bool(self.kb.about("nono", ["model1"])))
+        self.assertFalse(bool(self.kb.about("nono", ["model2"])))
 
+        
     def test_events(self):
 
         eventtriggered = [False]


### PR DESCRIPTION
As a consequence of this bug, models would be ignored when using 'about'.

Unit-test testing this issue is provided.
